### PR TITLE
Fix: null displayName for /mods

### DIFF
--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -1284,7 +1284,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         {
                             mods.append(result.mods.at(i)
                                             .toObject()
-                                            .value("displayName")
+                                            .value("login")
                                             .toString());
                         }
 
@@ -3237,7 +3237,7 @@ void CommandController::initialize(Settings &, Paths &paths)
                         {
                             vips.append(result.vips.at(i)
                                             .toObject()
-                                            .value("displayName")
+                                            .value("login")
                                             .toString());
                         }
 


### PR DESCRIPTION
IVR was returning null for mods `displayName`, switched both /mods & /vips to use `login` instead

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
