### PR TITLE
flake.nix: handle supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         "x86_64-linux"
         "aarch64-linux"
       ];
-      default =
+      mkDefault =
         path:
         nixpkgs.lib.genAttrs supportedSystems (system: {
           default = import path { inherit (nixpkgs.legacyPackages.${system}) pkgs; };
@@ -24,7 +24,7 @@
     in
 
     {
-      packages = default ./.;
-      devShells = default ./shell.nix;
+      packages = mkDefault ./.;
+      devShells = mkDefault ./shell.nix;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,14 +6,25 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
-    system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${system};
-  in {
-    packages.${system}.default = import ./. {inherit pkgs;};
-    devShells.${system}.default = import ./shell.nix {inherit pkgs;};
-  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      default =
+        path:
+        nixpkgs.lib.genAttrs supportedSystems (system: {
+          default = import path { inherit (nixpkgs.legacyPackages.${system}) pkgs; };
+        });
+    in
+
+    {
+      packages = default ./.;
+      devShells = default ./shell.nix;
+    };
 }


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

currently, `x86` is the only system that is supported through our flake. this pr adds support for `aarch64`, as well as other systems in the future